### PR TITLE
fix: Google Login Already SignUp Logic Bug

### DIFF
--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -62,10 +62,10 @@ class AuthController extends GetxController {
     loginUserInfo["profileImgUrl"] = googleUser?.photoUrl;
 
     if (await _apiProvider.isAccountAlreadySignUp(loginUserInfo["userid"], "google")) {
-      Get.to(RegisterUserInfo());
-    } else {
       await _apiProvider.userLogin("google", loginUserInfo["userid"]);
       isLogin.value = true;
+    } else {
+      Get.to(RegisterUserInfo());
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.0+1
+version: 1.0.1+2
 
 environment:
   sdk: ">=2.16.2 <3.0.0"


### PR DESCRIPTION
구글 로그인 로직 중 이미 가입되어있는지 체크하는 로직이 있는데, 본 로직이 잘못된 것을 발견하여 수정 후 PR합니다.